### PR TITLE
Put `asdf-odo` repository under Terraform control

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -643,6 +643,26 @@ locals {
       ]
     }
 
+    asdf-odo = {
+      description    = "asdf version manager plugin for odo, the developer-focused CLI for fast and iterative application development on Podman, Kubernetes and OpenShift"
+      homepage_url   = "https://odo.dev"
+      default_branch = "main"
+      topics = [
+        "asdf-plugin",
+        "asdf",
+        "application-development",
+        "developer-tools",
+        "kubernetes",
+        "odo",
+        "openshift",
+        "podman",
+      ]
+      teams = [
+        "asdf-core",
+        "asdf-odo",
+      ]
+    }
+
     asdf-opam = {
       description    = "opam plugin for the asdf version manager"
       homepage_url   = "https://github.com/asdf-vm/asdf"

--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -658,8 +658,8 @@ locals {
         "podman",
       ]
       teams = [
-        "asdf-core",
         "asdf-odo",
+        "asdf-core",
       ]
     }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/asdf-community/infrastructure/pull/50, in the process of migrating `asdf-odo` into this community organization.
I've already transferred the repository - see https://github.com/asdf-community/asdf-odo

Thanks!