### PR TITLE
Add asdf-plugin-manager team

### DIFF
--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -271,6 +271,13 @@ locals {
       ]
     }
 
+    asdf-plugin-manager = {
+      description = "The people with push access to the asdf-plugin-manager repository"
+      maintainers = [
+        "aabouzaid",
+      ]
+    }
+
     asdf-python = {
       description = "The people with push access to the asdf-python repository"
       maintainers = [


### PR DESCRIPTION
Hi @smorimoto :wave: 

Following your comment in https://github.com/orgs/asdf-community/discussions/46
This is the first step to moving [asdf-plugin-manager](https://github.com/aabouzaid/asdf-plugin-manager) to community org.

Second step: [Import asdf-plugin-manager repository](https://github.com/asdf-community/infrastructure/pull/61)

Thanks :rocket: 