### PR TITLE
Import asdf-plugin-manager repository

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -759,6 +759,21 @@ locals {
       ]
     }
 
+    asdf-plugin-manager = {
+      description    = "A plugin manager for the asdf version manager"
+      homepage_url   = "https://github.com/asdf-vm/asdf"
+      default_branch = "main"
+      topics = [
+        "asdf-plugin",
+        "asdf",
+        "security",
+      ]
+      teams = [
+        "asdf-plugin-manager",
+        "asdf-core",
+      ]
+    }
+
     asdf-python = {
       description    = "Python plugin for the asdf version manager"
       homepage_url   = "https://github.com/asdf-vm/asdf"


### PR DESCRIPTION
Hi @smorimoto :wave: 

Following your comment in https://github.com/orgs/asdf-community/discussions/46
This is the second step to moving [asdf-plugin-manager](https://github.com/aabouzaid/asdf-plugin-manager) to community org.

First step: [Add asdf-plugin-manager team](https://github.com/asdf-community/infrastructure/pull/60)

Thanks :rocket: 