### PR TITLE
Add Pomerium-CLI Plugin

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -815,6 +815,13 @@ locals {
       ]
     }
 
+    asdf-pomerium-cli = {
+      description = "The people with push access to the asdf-pomerium-cli repository"
+      maintainers = [
+        "haggishunk",
+      ]
+    }
+
     asdf-plugin-manager = {
       description    = "A plugin manager for the asdf version manager"
       homepage_url   = "https://github.com/asdf-vm/asdf"


### PR DESCRIPTION
Adds the initial github infra terraform data for migration of haggishunk/asdf-pomerium-cli to the asdf-community organization.

Signed-off-by: Travis Mattera <travis@mattera.io>
