### PR TITLE
Include the asdf-tuist and asdf-tuits-cloud repositories

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -1080,6 +1080,34 @@ locals {
         "asdf-core",
       ]
     }
+
+    asdf-tuist = {
+      description    = "Tuist CLI plugin for the asdf version manager"
+      homepage_url   = "https://github.com/tuist/tuist"
+      default_branch = "main"
+      topics = [
+        "asdf-plugin",
+        "asdf",
+      ]
+      teams = [
+        "asdf-tuist",
+        "asdf-core",
+      ]
+    }
+
+    asdf-tuist-cloud = {
+      description    = "Tuist Cloud CLI plugin for the asdf version manager"
+      homepage_url   = "https://github.com/tuist/tuist"
+      default_branch = "main"
+      topics = [
+        "asdf-plugin",
+        "asdf",
+      ]
+      teams = [
+        "asdf-tuist-cloud",
+        "asdf-core",
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
After merging [this PR](https://github.com/asdf-community/infrastructure/pull/119), I've moved the `asdf-tuist` and `asdf-tuist-cloud` repositories to the `asdf-community` organization. This PR adds those repositories to the terraform configuration in this repo.