### PR TITLE
Change asdf-pandoc to be maintained by StephanMeijer and Fbrisset

### DIFF
--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -341,7 +341,7 @@ locals {
     asdf-pandoc = {
       description = "The people with push access to the asdf-pandoc repository",
       maintainers = [
-        "sys9kdr",
+        "StephanMeijer",
       ]
     }
 

--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -341,7 +341,7 @@ locals {
     asdf-pandoc = {
       description = "The people with push access to the asdf-pandoc repository",
       maintainers = [
-        "StephanMeijer", "Fbrisset",
+        "StephanMeijer", "Fbrisset", "sys9kdr",
       ]
     }
 

--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -341,7 +341,7 @@ locals {
     asdf-pandoc = {
       description = "The people with push access to the asdf-pandoc repository",
       maintainers = [
-        "StephanMeijer",
+        "StephanMeijer", "Fbrisset",
       ]
     }
 


### PR DESCRIPTION
asdf-pandoc does not seem to have been claimed as community repository. I would like to do so so that I can work on my changes as a community effort.

@Fbrisset is the current maintainer of the repository present in the [Index](https://github.com/asdf-vm/asdf-plugins/blob/master/plugins/pandoc).