### PR TITLE
Add aws-vault team

### DIFF
--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -43,6 +43,13 @@ locals {
       ]
     }
 
+    asdf-aws-vault = {
+      description = "The people with push access to the asdf-aws-vault repository"
+      maintainers = [
+        "elijahr",
+      ]
+    }
+
     asdf-bitwarden-secrets-manager = {
       description = "The people with push access to the asdf-bitwarden-secrets-manager repository"
       maintainers = [


### PR DESCRIPTION
I'm already a member of the org - maintain the asdf-nim plugin.

The asdf-aws-vault plugin was abandoned and needed an update, so I forked it to https://github.com/asdf-community/asdf-aws-vault

Apologies for not first checking the guidelines on adding plugins to asdf-community.

If I need to delete the https://github.com/asdf-community/asdf-aws-vault repository I already created for terraform to work correctly, please let me know.

Thanks!